### PR TITLE
Ensure JSX output is ES5 compatible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ export default function svgToJS (config) {
     iife: `/*!${banner}*/\n(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none">${icons.map(({ symbol }) => symbol).join('')}</svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`,
     cjs: icons.map(({ camelCase, svg }) => `exports.${camelCase} = '${svg}'`).join('\n'),
     esm: icons.map(({ camelCase, svg }) => `export const ${camelCase} = '${svg}'`).join('\n'),
-    cjsx: `const React = require('react')${icons.map(({ titleCase, jsx }) => `\nexports.${titleCase} = function () {${jsx}}`).join('')}`,
+    cjsx: `var React = require('react')${icons.map(({ titleCase, jsx }) => `\nexports.${titleCase} = function () {${jsx}}`).join('')}`,
     esmx: `import React from 'react'${icons.map(({ titleCase, jsx }) => `\nexport function ${titleCase} () {${jsx}}`).join('')}`,
     dts: icons.map(({ camelCase }) => `export declare const ${camelCase}: string`).join('\n'),
     dtsx: icons.map(({ titleCase }) => `export declare const ${titleCase}: React.FunctionComponent<React.SVGProps<SVGElement>>`).join('\n')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,4 +50,8 @@ describe('svg-to-js', () => {
     expect(document.querySelectorAll('symbol').length).toBe(2)
     expect(document.querySelectorAll('svg').length).toBe(1)
   })
+
+  it('jsx should be ES5 compatible', () => {
+    expect(result.cjsx).not.toMatch(/(const|let)\s?=/)
+  })
 })


### PR DESCRIPTION
We've had some production issues lately where older clients like IE11 and iOS 9.3 break because our bundle contains ES5 incompatible tokens. This PR gets rid of `const` in favor of `var` ensuring compatiblity with older browsers.

If anyone else runs into the same problem I can highly recommend [es-check](https://github.com/dollarshaveclub/es-check) that's easily integrated into a build with something like `webpack && es-check es5 dist/*.js`