### PR TITLE
Malformed viewBox in SVG

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,13 @@ export default function svgToJS (config) {
     const camelCase = name.replace(/-+./g, (m) => m.slice(-1).toUpperCase())
     const titleCase = camelCase.replace(/./, (m) => m.toUpperCase())
     const [w, h] = size.split(' ').slice(2).map((val) => `${(val / scale).toFixed(3)}em`)
-    if (!h) throw new Error(`Malformed viewBox in SVG ${file}`)
+    if (!h) { 
+      // throw new Error(("Malformed viewBox in SVG " + file)) 
+    
+      w = String(code.match(/width="[^"]+/)).slice(7);
+      h = String(code.match(/height="[^"]+/)).slice(8);
+      size = `0 0 ${w} ${h}`
+    }
 
     icons.push({
       camelCase,


### PR DESCRIPTION
svg-to-js errors on svg files that use height and width and have no viewBox.

Error: Malformed viewBox in SVG attention-token-of-media-atm-logo.svg