### PR TITLE
Viewbox fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > Module for concatenating SVG files into JavaScript.
 
 ##### Why load icons as JavaScript?
-SVG symbols are great for styling and accessibility, but can not load cross domain, or from external file and in IE (9,10,11). Javascript provides us a cacheable, cross-domain method load the icons, without adding extra overhead to each html-file.
+SVG symbols are great for styling and accessibility, but can not load cross domain, or from external file and in IE (9,10,11). Javascript provides us a cacheable, cross-domain method to load the icons, without adding extra overhead to each html-file.
 
 ## Installation
 
@@ -13,18 +13,18 @@ npm install @nrk/svg-to-js
 ## Usage
 
 ```js
-import svgtojs = from '@nrk/svg-to-js'
+import svgtojs from '@nrk/svg-to-js'
 
 const options = {
   input: 'src/'               // Required. Folder with SVG files
-  banner: 'Copyright NRK',    // Optional. Text to add to top of file
-  scale: 1,                   // Optional. Scale factor for  width/height attributes in em
+  banner: 'Copyright NRK',    // Optional. Text to add as comment in top of file
+  scale: 1,                   // Optional. Scale factor for width/height attributes in em
 
   // svgtojs always returns Object of outputs,
   // but can optionally also write files:
   esm: 'core-icons.esm.js',   // ES module for bundlers exposing `export const iconName = '<svg...'`
   cjs: 'core-icons.js',       // CommonJS for Node exposing `module.exports = { iconName: '<svg...' }`
-  esmx 'core-icons.esm.jsx',  // JSX ES module, exposing React components with `export`
+  esmx: 'core-icons.esm.jsx', // JSX ES module, exposing React components with `export`
   cjsx: 'core-icons.cjs.jsx', // JSX CommonJS, exposing React components with `module.exports`
   iife: 'core-icons.min.js'   // Self executing <script>, exposing all icons as symbols on page,
   dts: 'core-icons.d.ts',     // Exposes typescript definitions with `export declare const`

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,13 +26,16 @@ export default function svgToJS (config) {
   for (const file of files) {
     if (file.slice(-4) !== '.svg') continue
     const code = fs.readFileSync(path.join(config.input, file), 'utf-8')
-    const size = String(code.match(/viewBox="[^"]+/)).slice(9)
+    const size = String(code.match(/viewBox="[^"]+/)).slice(9) || `0 0 ${String(code.match(/width="[^"]+/)).slice(7)} ${String(code.match(/width="[^"]+/)).slice(7)}`
     const name = file.slice(0, -4)
     const body = code.replace(/^[^>]+>|<[^<]+$/g, '').replace(/\s*([<>])\s*/g, '$1') // Minified SVG body
     const camelCase = name.replace(/-+./g, (m) => m.slice(-1).toUpperCase())
     const titleCase = camelCase.replace(/./, (m) => m.toUpperCase())
-    const [w, h] = size.split(' ').slice(2).map((val) => `${(val / scale).toFixed(3)}em`)
-    if (!h) throw new Error(`Malformed viewBox in SVG ${file}`)
+    const [w, h] = size.split(' ').slice(2).map((val) => Number(val) && `${(val / scale).toFixed(3)}em`)
+
+    if (!h || !w) {
+      throw new Error(('Malformed viewBox or bad width/height in SVG ' + file))
+    }
 
     icons.push({
       camelCase,
@@ -53,7 +56,7 @@ export default function svgToJS (config) {
     dtsx: icons.map(({ titleCase }) => `export declare const ${titleCase}: React.FunctionComponent<React.SVGProps<SVGElement>>`).join('\n')
   }
 
-  // Save files if specified in config
+  // Save files if filename is specified in config
   Object.keys(config).forEach((type) => {
     if (result[type]) fs.writeFileSync(config[type], result[type])
   })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,22 @@
 import path from 'path'
 import fs from 'fs'
 
+/**
+ * svgToJS Concatenates SVG-files into Javascript
+ * @param {Object} config
+ * @param {String} config.input Required. Folder with SVG-files
+ * @param {String} [config.banner='svg-to-js'] Optional. Text to add as comment in top of file
+ * @param {Number} [config.scale=1] Optional. Scale factor for width/height attributes in em
+ * @param {String} [config.cjs] Optional. Specify filename to write ES module for bundlers exposing `export const iconName = '<svg...'`
+ * @param {String} [config.cjsx] Optional. Specify filename to write CommonJS for Node exposing `module.exports = { iconName: '<svg...' }`
+ * @param {String} [config.esm] Optional. Specify filename to write JSX ES module, exposing React components with `export`
+ * @param {String} [config.esmx] Optional. Specify filename to write JSX CommonJS, exposing React components with `module.exports`
+ * @param {String} [config.iife] Optional. Specify filename to write Self executing <script>, exposing all icons as symbols on page,
+ * @param {String} [config.dts] Optional. Specify filename to write TypeScript definitions with `export declare const`
+ * @param {String} [config.dtsx] Optional. Specify filename to write TypeScript definitions for JSX with `export declare const`
+ * @throws {Error} Throws Error if svg has no viewBox or width/height
+ * @returns {Object}
+ */
 export default function svgToJS (config) {
   const banner = config.banner || 'svg-to-js'
   const scale = config.scale || 1

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,12 @@
 const svgtojs = require('../lib/svg-to-js.cjs.js')
 
-const blueprint = `/*!Copyright*/
-(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><symbol viewBox="0 0 15 15" id="nrk-bell"><path stroke="currentColor" fill="none" d="M7.5081246 2.5C4.0162492 2.5 4 5.38865948 4 6.2861215V9c0 1-1.5166599 1.7192343-1.5 2 .03450336.5814775.27977082.4920386.9090909.4920386h8.1818182C12.2186267 11.4920386 12.5 11.5 12.5 11c0-.3060964-1.5-1-1.5-2V6.2861215C11 5.35488333 11 2.5 7.5081246 2.5z"/><path d="M8.75 12.5h-2.5s0 1.25 1.25 1.25 1.25-1.25 1.25-1.25z"/><path stroke="currentColor" d="M7.5 1.5V2" stroke-linecap="round"/></symbol><symbol viewBox="0 0 15 15" id="nrk-close"><path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/></symbol></svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`
+const BANNER_TEXT = 'Copyright'
+
+const BLUEPRINT = `/*!${BANNER_TEXT}*/
+(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><symbol viewBox="0 0 15 15" id="nrk-bell"><path stroke="currentColor" fill="none" d="M7.5081246 2.5C4.0162492 2.5 4 5.38865948 4 6.2861215V9c0 1-1.5166599 1.7192343-1.5 2 .03450336.5814775.27977082.4920386.9090909.4920386h8.1818182C12.2186267 11.4920386 12.5 11.5 12.5 11c0-.3060964-1.5-1-1.5-2V6.2861215C11 5.35488333 11 2.5 7.5081246 2.5z"/><path d="M8.75 12.5h-2.5s0 1.25 1.25 1.25 1.25-1.25 1.25-1.25z"/><path stroke="currentColor" d="M7.5 1.5V2" stroke-linecap="round"/></symbol><symbol viewBox="0 0 15 15" id="nrk-close-no-viewBox"><path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/></symbol><symbol viewBox="0 0 15 15" id="nrk-close"><path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/></symbol></svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`
 
 const result = svgtojs({
-  banner: 'Copyright',
+  banner: BANNER_TEXT,
   input: __dirname
 })
 
@@ -14,7 +16,7 @@ describe('svg-to-js', () => {
   })
 
   it('iife should start with banner', () => {
-    expect(result.iife.indexOf('/*!Copyright*/')).toBe(0)
+    expect(result.iife.indexOf(`/*!${BANNER_TEXT}*/`)).toBe(0)
   })
 
   it('iife should contain svg ids', () => {
@@ -37,17 +39,17 @@ describe('svg-to-js', () => {
   })
 
   it('iife should contain all symbols', () => {
-    expect(result.iife.match(/<symbol/g).length).toBe(2)
+    expect(result.iife.match(/<symbol/g).length).toBe(3)
   })
 
   it('iife should equal blueprint', () => {
-    expect(result.iife).toBe(blueprint)
+    expect(result.iife).toBe(BLUEPRINT)
   })
 
   it('executing iife should append to document', () => {
     document.body.innerHTML = result.iife
     expect(document.querySelectorAll('#nrk-bell').length).toBe(1)
-    expect(document.querySelectorAll('symbol').length).toBe(2)
+    expect(document.querySelectorAll('symbol').length).toBe(3)
     expect(document.querySelectorAll('svg').length).toBe(1)
   })
 

--- a/test/nrk-close-no-viewBox.svg
+++ b/test/nrk-close-no-viewBox.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="15" width="15">
+<path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/>
+</svg>


### PR DESCRIPTION
- Look for width/height attributes when missing viewBox
- Throw error on missing values for width or height. Treat non-numerics as invalid values.
- Added JSDoc and cleaned up some typos in documentation.

Thanks to leoplaw for raising the issue
 
Resolves #12, closes #13 