### PR TITLE
feat: Add optional config key style

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ import fs from 'fs'
  * @param {String} [config.iife] Optional. Specify filename to write Self executing <script>, exposing all icons as symbols on page,
  * @param {String} [config.dts] Optional. Specify filename to write TypeScript definitions with `export declare const`
  * @param {String} [config.dtsx] Optional. Specify filename to write TypeScript definitions for JSX with `export declare const`
+ * @param {CSSStyleDeclaration} [config.style] Optional. CSS-styles to be passed to icon
  * @throws {Error} Throws Error if svg has no viewBox or width/height
  * @returns {Object}
  */
@@ -33,6 +34,11 @@ export default function svgToJS (config) {
     const titleCase = camelCase.replace(/./, (m) => m.toUpperCase())
     const [w, h] = size.split(' ').slice(2).map((val) => Number(val) && `${(val / scale).toFixed(3)}em`)
 
+    // Convert CSSStyleDeclaration to html-style
+    const htmlStyle = config.style ? ` style="${Object.keys(config.style).reduce((prev, key) => prev + `${key.replace(/[A-Z]/g, m => '-' + m.toLowerCase())}: ${config.style[key]};`, '')}"` : ''
+    // Convert CSSStyleDeclaration to jsx-style
+    const jsxStyle = config.style ? ` style: ${JSON.stringify(config.style)}` : ''
+
     if (!h || !w) {
       throw new Error(('Malformed viewBox or bad width/height in SVG ' + file))
     }
@@ -40,9 +46,9 @@ export default function svgToJS (config) {
     icons.push({
       camelCase,
       titleCase,
-      symbol: `<symbol viewBox="${size}" id="${name}">${body}</symbol>`,
-      svg: `<svg viewBox="${size}" class="${name}" width="${w}" height="${h}" aria-hidden="true" focusable="false">${body}</svg>`,
-      jsx: `return React.createElement('svg', {'aria-hidden': true, width: '${w}', height: '${h}', viewBox: '${size}', dangerouslySetInnerHTML: {__html: '${body}'}})`
+      symbol: `<symbol viewBox="${size}" id="${name}"${htmlStyle}>${body}</symbol>`,
+      svg: `<svg viewBox="${size}" class="${name}" width="${w}" height="${h}" aria-hidden="true" focusable="false"${htmlStyle}>${body}</svg>`,
+      jsx: `return React.createElement('svg', {'aria-hidden': true, width: '${w}', height: '${h}', viewBox: '${size}', ${jsxStyle} dangerouslySetInnerHTML: {__html: '${body}'}})`
     })
   }
 


### PR DESCRIPTION
Enhancement related to https://github.com/nrkno/origo/issues/663

Adds optional `style`-key to config as CSSStyleDeclaration, similar to what React.createElement accepts, giving users a familiar type-ahead.
```
const styledResult = svgtojs({
  (...),
  style: { backgroundColor: 'papayawhip' }
})
```