### PR TITLE
feat: Support props for React/jsx icons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,11 @@ export default function svgToJS (config) {
       titleCase,
       symbol: `<symbol viewBox="${size}" id="${name}">${body}</symbol>`,
       svg: `<svg viewBox="${size}" class="${name}" width="${w}" height="${h}" aria-hidden="true" focusable="false">${body}</svg>`,
-      jsx: `return React.createElement('svg', {'aria-hidden': true, width: '${w}', height: '${h}', viewBox: '${size}', dangerouslySetInnerHTML: {__html: '${body}'}})`
+      jsx: `
+        var attributes = {'aria-hidden': true, width: '${w}', height: '${h}', viewBox: '${size}', dangerouslySetInnerHTML: {__html: '${body}'}}
+        if (props) Object.keys(props).forEach(function (key) { attributes[key] = props[key] })
+        return React.createElement('svg', attributes)
+      `.trim()
     })
   }
 
@@ -50,8 +54,8 @@ export default function svgToJS (config) {
     iife: `/*!${banner}*/\n(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none">${icons.map(({ symbol }) => symbol).join('')}</svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`,
     cjs: icons.map(({ camelCase, svg }) => `exports.${camelCase} = '${svg}'`).join('\n'),
     esm: icons.map(({ camelCase, svg }) => `export const ${camelCase} = '${svg}'`).join('\n'),
-    cjsx: `var React = require('react')${icons.map(({ titleCase, jsx }) => `\nexports.${titleCase} = function () {${jsx}}`).join('')}`,
-    esmx: `import React from 'react'${icons.map(({ titleCase, jsx }) => `\nexport function ${titleCase} () {${jsx}}`).join('')}`,
+    cjsx: `var React = require('react')${icons.map(({ titleCase, jsx }) => `\nexports.${titleCase} = function (props) {${jsx}}`).join('')}`,
+    esmx: `import React from 'react'${icons.map(({ titleCase, jsx }) => `\nexport function ${titleCase} (props) {${jsx}}`).join('')}`,
     dts: icons.map(({ camelCase }) => `export declare const ${camelCase}: string`).join('\n'),
     dtsx: icons.map(({ titleCase }) => `export declare const ${titleCase}: React.FunctionComponent<React.SVGProps<SVGElement>>`).join('\n')
   }


### PR DESCRIPTION
* Support props with potential override for React/jsx icons to match declaration

Tested in local Origo to generate React components for icons with support for props overrides

Enhancement related to nrkno/origo#663