### PR TITLE
Jsx wrap hyphenated attributes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,15 @@
  */
 
 /**
+ * wraps hyphenated string in single-quotes to avoid issues in jsx object-syntax
+ * @param {string} attrKey
+ * @returns string
+ */
+function stringifyHyphenatedKey (attrKey) {
+  return attrKey.indexOf('-') === -1 ? attrKey : `'${attrKey}'`
+}
+
+/**
  * Parses stringified svg-markup for presentation attributes and returns an object with relevant formats for use
  * @param {string} markup Stringified svg markup
  * @return {MissingSvgPresentationAttributes | SvgPresentationAttributes}
@@ -48,7 +57,7 @@ export function parseSVGTagPresentationAttributes (markup) {
   return {
     foundAttributes: true,
     svgAttrStr: Object.keys(attrs).reduce((content, key) => content + `${key}="${attrs[key]}" `, '').trim(),
-    svgAttrStrJsx: Object.keys(attrs).reduce((content, key) => content + `, ${key}: '${attrs[key]}'`, '').trim()
+    svgAttrStrJsx: Object.keys(attrs).reduce((content, key) => content + `, ${stringifyHyphenatedKey(key)}: '${attrs[key]}'`, '').trim()
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ const svgtojs = require('../lib/svg-to-js.cjs.js')
 const BANNER_TEXT = 'Generated using @nrk/svg-to-js'
 
 const BLUEPRINT = `/*!${BANNER_TEXT}*/
-(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><symbol viewBox="0 0 24 24" id="nrk-bell" ><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M13 1h-2v1.05475C7.86324 2.40036 5 4.38211 5 8v8.5L3 18v2h18v-2l-2-1.5V8c0-3.61788-2.8632-5.59963-6-5.94525V1zm1 20H9.99999c0 1.1046.89541 2 2.00001 2s2-.8954 2-2zM11.9974 4h.0052c1.3984.00051 2.6978.40515 3.5978 1.09086C16.4454 5.73464 17 6.65971 17 8v9.5l.6667.5H6.33333L7 17.5V8c0-1.34029.55463-2.26536 1.39959-2.90914.9-.68571 2.19941-1.09035 3.59781-1.09086z"/></symbol><symbol viewBox="0 0 15 15" id="nrk-close-no-viewBox" ><path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/></symbol><symbol viewBox="0 0 24 24" id="nrk-close" ><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 10.5858l6.2929-6.29289 1.4142 1.41421L13.4142 12l6.2929 6.2929-1.4142 1.4142L12 13.4142l-6.29288 6.2929-1.41421-1.4142L10.5858 12 4.29291 5.70712l1.41421-1.41421L12 10.5858z"/></symbol><symbol viewBox="0 0 24 24" id="nrk-download" fill="currentColor"><path d="M13 2h-2v15.1l-7-4.4V15l8 5 8-5v-2.3l-7 4.4V2Z"/><path d="M4 22h16v2H4z" opacity=".5"/></symbol></svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`
+(function(el){el.innerHTML='<svg xmlns="http://www.w3.org/2000/svg" style="display:none"><symbol viewBox="0 0 24 24" id="nrk-bell" ><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M13 1h-2v1.05475C7.86324 2.40036 5 4.38211 5 8v8.5L3 18v2h18v-2l-2-1.5V8c0-3.61788-2.8632-5.59963-6-5.94525V1zm1 20H9.99999c0 1.1046.89541 2 2.00001 2s2-.8954 2-2zM11.9974 4h.0052c1.3984.00051 2.6978.40515 3.5978 1.09086C16.4454 5.73464 17 6.65971 17 8v9.5l.6667.5H6.33333L7 17.5V8c0-1.34029.55463-2.26536 1.39959-2.90914.9-.68571 2.19941-1.09035 3.59781-1.09086z"/></symbol><symbol viewBox="0 0 15 15" id="nrk-close-no-viewBox" ><path stroke="currentColor" stroke-linecap="round" d="M2 2l11 11M2 13L13 2"/></symbol><symbol viewBox="0 0 24 24" id="nrk-close" ><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 10.5858l6.2929-6.29289 1.4142 1.41421L13.4142 12l6.2929 6.2929-1.4142 1.4142L12 13.4142l-6.29288 6.2929-1.41421-1.4142L10.5858 12 4.29291 5.70712l1.41421-1.41421L12 10.5858z"/></symbol><symbol viewBox="0 0 24 24" id="nrk-download" fill="currentColor"><path d="M13 2h-2v15.1l-7-4.4V15l8 5 8-5v-2.3l-7 4.4V2Z"/><path d="M4 22h16v2H4z" opacity=".5"/></symbol><symbol viewBox="0 0 24 24" id="nrk-media-direkte-notlive" fill-rule="evenodd" fill="currentColor"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm12-10c0 6.627-5.373 12-12 12S0 18.627 0 12 5.373 0 12 0s12 5.373 12 12Z" opacity=".5"/><path d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm5-2a5 5 0 1 1-10 0 5 5 0 0 1 10 0Z"/></symbol></svg>';document.head.appendChild(el.firstElementChild)})(document.createElement('div'))`
 
 const result = svgtojs({
   banner: BANNER_TEXT,
@@ -63,6 +63,16 @@ describe('svg-to-js', () => {
   it('should keep all presentation attributes from svg-tag on symbol for iife', () => {
     document.body.innerHTML = result.iife
     expect(document.querySelector('symbol#nrk-download').attributes.fill.value).toBe('currentColor')
+  })
+
+  it('should wrap hyphenated attribute-keys in single-quotes', () => {
+    const nrkMediaDirekteNotliveExport = result.cjsx.split('exports.').filter(v => v.startsWith('NrkMediaDirekteNotlive'))[0]
+    expect(nrkMediaDirekteNotliveExport.indexOf("'fill-rule': 'evenodd'") !== -1).toBe(true)
+  })
+
+  it('should not wrap unhyphenated attribute-keys in single-quotes', () => {
+    const nrkMediaDirekteNotliveExport = result.cjsx.split('exports.').filter(v => v.startsWith('NrkMediaDirekteNotlive'))[0]
+    expect(nrkMediaDirekteNotliveExport.indexOf("'fill':") === -1).toBe(true)
   })
 
   it('should keep presentation attributes from svg-tag on svg for cjs', () => {

--- a/test/nrk-media-direkte-notlive.svg
+++ b/test/nrk-media-direkte-notlive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" viewBox="0 0 24 24" fill="currentColor"><path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm12-10c0 6.627-5.373 12-12 12S0 18.627 0 12 5.373 0 12 0s12 5.373 12 12Z" opacity=".5"/><path d="M12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm5-2a5 5 0 1 1-10 0 5 5 0 0 1 10 0Z"/></svg>


### PR DESCRIPTION
This PR fixes syntax-error in jsx output when svg-tag contains hyphenated attributes like `fill-rule`.
* hyphenated keys are wrapped in single-quotes
* we leave un-hyphenated keys verbatim to avoid bloat

Today we emit: (note the lack of syntax-highlighting on the hyphenated key)
```JavaScript
var attributes = {
  fill-rule: 'evenodd',
  fill: 'currentColor'
}
```

We add a single-quote wrap to make them valid js object-keys like
```JavaScript
var attributes = {
  'fill-rule': 'evenodd',
   fill: 'currentColor'
}
``` 