### PR TITLE
feat: Add dtsLiteral to config to write literal types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ import { parseSVGTagPresentationAttributes } from './utils'
  * @param {String} [config.iife] Optional. Specify filename to write Self executing <script>, exposing all icons as symbols on page,
  * @param {String} [config.dts] Optional. Specify filename to write TypeScript definitions with `export declare const`
  * @param {String} [config.dtsx] Optional. Specify filename to write TypeScript definitions for JSX with `export declare const`
+ * @param {String} [config.dtsLiteral] Optional. Specify filename to write TypeScript definitions as literal types with `export declare const iconName: '<svg...'`.
  * @param {[{parser: Function, filename?: String, includeBanner?: Boolean}]} [config.customOutputs] Optional. List of configs to generate custom parsed output-files
  * @throws {Error} Throws Error if svg has no viewBox or width/height
  * @returns {Object}
@@ -63,7 +64,8 @@ export default function svgToJS (config) {
     cjsx: `var React = require('react')${icons.map(({ titleCase, jsx }) => `\nexports.${titleCase} = function (props) {${jsx}}`).join('')}`,
     esmx: `import React from 'react'${icons.map(({ titleCase, jsx }) => `\nexport function ${titleCase} (props) {${jsx}}`).join('')}`,
     dts: icons.map(({ camelCase }) => `export declare const ${camelCase}: string`).join('\n'),
-    dtsx: icons.map(({ titleCase }) => `export declare const ${titleCase}: React.FunctionComponent<React.SVGProps<SVGElement>>`).join('\n')
+    dtsx: icons.map(({ titleCase }) => `export declare const ${titleCase}: React.FunctionComponent<React.SVGProps<SVGElement>>`).join('\n'),
+    dtsLiteral: icons.map(({ camelCase, svg }) => `export declare const ${camelCase}: '${svg}'`).join('\n')
   };
 
   // Merge customOutputs to result if customOutputs are specified in config


### PR DESCRIPTION
Declared literal types allow consumers to create more rigid type guards in their projects.

Moves the proposed literal types addition proposed in https://github.com/nrkno/core-icons/pull/303 to a feature of svg-to-js and added @torgeilo as co-author.

This change constitutes a minor change to the package.

Note: Made a couple of attempts to use the typescript compiler to verify that the generated .d.ts -strings are valid types within the jest test-rig to no immediate avail, so the changes are tested manually. Would love some input on how we can validate the syntax generated by a library, and not the types of the library itself.